### PR TITLE
Error: Gulp command not found. Fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TodoMVC app written in Elm and using Electron.
 
 ## Development
 
-1. Run `gulp`.
+1. Run `npm run gulp`.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "gulp-cssmin": "^0.1.7",
     "gulp-elm": "^0.4.2",
     "gulp-sass": "^2.3.2"
+  },
+  "scripts": {
+    "gulp": "gulp"
   }
 }


### PR DESCRIPTION
Found this blog post, seemed to help: https://www.sitepoint.com/solve-global-npm-module-dependency-problem/

**Issue number:** #3 
