### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,13 +39,13 @@ gulp.task('sass', function() {
  */
 gulp.task('elm', ['elm-init', 'copy-assets'], function(){
   return gulp.src('src/*.elm')
-    .pipe(elm.make({filetype: 'js'}))
+    .pipe(elm.bundle('app.js'))
     .pipe(gulp.dest('app/'))
     .pipe(browserSync.reload({stream:true}));
 });
 
 /**
- * Watch HTML and SCSS files for changes and copy them.
+ * Watch HTML and SCSS files for changes and copy them. In case you have any other assets (i.e. png), put an extra 'src/*.png' or similar to the 'gulp-watch' parameters
  * Watch Elm files, recompile them and reload BrowserSync.
  */
 gulp.task('watch', function() {


### PR DESCRIPTION
Small mod: the current version can only compile 1 elm module which is not very flexible. Using "elm.bundle" is more lifelike - it will compile all module to one "app.js". Also, asset-copy should be extended to other asset types - but that's of course optional.